### PR TITLE
feat: docker revision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:18-alpine
+# Building step
+FROM node:18-alpine as build
 
 RUN mkdir -p /usr/src/app
 
@@ -11,7 +12,12 @@ RUN npm ci
 COPY . .
 
 RUN npm run build
-## EXPOSE [Port you mentioned in the vite.config file]
-EXPOSE 3000
 
-CMD ["npm", "run", "preview"]
+# Now we're gonna serve the app in a nginx instance
+FROM nginx:stable-alpine AS nginx
+
+COPY --from=build /usr/src/app/dist/ /usr/share/nginx/html/
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;" ]

--- a/README.md
+++ b/README.md
@@ -53,13 +53,16 @@ docker-compose -f docker-compose-dev.yml up
 
 ### Using on Production with Docker
 
-DISCLAIMER: This Docker configuration is for demonstration purposes only. If you plan to use this configuration in a production environment, it is your responsibility to ensure that it is secure and optimized for your needs. You should thoroughly test and review all aspects of the configuration before deploying it in a production environment. The author of this demonstration assumes no responsibility for any issues that may arise from the use of this configuration.
+DISCLAIMER: This Docker configuration is for demonstration purposes only. If you plan to use this configuration in a production remember to adjust the Dockerfile for your project's needs! 
 
 Making sure you're in your project directory, run:
 
 ```bash
 docker-compose -f docker-compose.yml up
 ```
+*By default it uses port 80*
+
+The production Dockerfile uses an nginx instance to run the built website, for more configuration options, see [nginx's dockerhub page](https://hub.docker.com/_/nginx)
 
 ## Try it online
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: eruption
     build: .
     ports:
-      - '3000:3000'
+      - '80:80'
     environment:
       - NODE_ENV=${NODE_ENV}
     # command: npm preview


### PR DESCRIPTION
This PR refactor our procution dockerfile to use nginx as web server instead of vite's builtin webserver (vite preview). This allow us to run an built static version of an eruption's website. The steps to use the Dockerfile should not be changed.
